### PR TITLE
Update ADT Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ The following are the ADTs implemented:
 
 Each ADT has the documentation for their operations in the README file inside their own directory. You can also read it in the `.h` file.
 
-Every ADT is for generic types, which means you could use it with most C datatypes. It's important to be careful with the elements added and obtained from the ADTs and how you cast them.
-
-The types of the elements added should be the same as the ones obtained if you don't want to lose information.
+Every ADT is for generic types, which means you could use it with most C datatypes. If you don't want to lose information, the types of the elements obtained should be casted as the same type as the ones added.
 
 An example with ADT Stack:
 
@@ -32,13 +30,13 @@ top = stack_pop(s);
 int obtained = *(int*)top;
 ```
 
-The file `assert_msg.h` is used for the testing. However, it must always be in the parent directory of any `.c` implementation file because they use them for error handling.
-
 With the given `.h` file in an ADT directory, you can implement your own version that respects the signatures for its operations.
 
 ## Testing
 
 Each ADT directory has it own `*_test.c` file that tests their operations, these tests don't depend on the implementation in the `.c` file.
+
+The file `assert_msg.h` is used for the testing. For the correct working of the tests, it must always be in the parent directory of any ADT directory.
 
 ## Compiling
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -16,13 +16,18 @@ Stack stack_create(void);
 /* Frees the memory where the stack is allocated */
 void stack_destroy(Stack stack);
 
-/* Add `elem`'s value into the top of the stack. */
-void stack_push(Stack stack, void* elem);
+/* Add `elem`'s value into the top of the stack. 
+
+POST:
+- Returns true if the item was successfully added to the stack, and false if there was an 
+issue with the operation. */
+bool stack_push(Stack stack, void* elem);
 
 /* Delete and return the value of the element at the top of the stack. If the stack does not
 have any element to pop, it must abort the flow. 
 
 POST:
+- If the queue is empty, a NULL pointer will be returned.
 - The returned pointer should be freed when not needed anymore.
 - A void pointer will be returned, the user should cast it to the right type. */
 void* stack_pop(Stack stack);
@@ -31,6 +36,7 @@ void* stack_pop(Stack stack);
 element to pop, it must abort the flow. 
 
 POST:
+- If the queue is empty, a NULL pointer will be returned.
 - A void pointer will be returned, the user should cast it to the right type.*/
 void* stack_top(const Stack stack);
 

--- a/stack/stack.h
+++ b/stack/stack.h
@@ -19,13 +19,18 @@ Stack stack_create(void);
 /* Frees the memory where the stack is allocated */
 void stack_destroy(Stack stack);
 
-/* Add `elem`'s value into the top of the stack. */
-void stack_push(Stack stack, void* elem);
+/* Add `elem`'s value into the top of the stack. 
+
+POST:
+- Returns true if the item was successfully added to the stack, and false if there was an 
+issue with the operation. */
+bool stack_push(Stack stack, void* elem);
 
 /* Delete and return the value of the element at the top of the stack. If the stack does not
 have any element to pop, it must abort the flow. 
 
 POST:
+- If the queue is empty, a NULL pointer will be returned.
 - The returned pointer should be freed when not needed anymore.
 - A void pointer will be returned, the user should cast it to the right type. */
 void* stack_pop(Stack stack);
@@ -34,10 +39,11 @@ void* stack_pop(Stack stack);
 element to pop, it must abort the flow. 
 
 POST:
+- If the queue is empty, a NULL pointer will be returned.
 - A void pointer will be returned, the user should cast it to the right type.*/
 void* stack_top(const Stack stack);
 
 /* Returns true if the stack is empty; otherwise, it returns false. */
 bool stack_is_empty(const Stack stack);
 
-#endif
+#endif // _STACK_H

--- a/stack/stack_test.c
+++ b/stack/stack_test.c
@@ -17,6 +17,9 @@ static void test_new_stack(void) {
     print_test(s != NULL, "Create a new stack");
     print_test(stack_is_empty(s), "A newly created stack must be empty");
 
+    print_test(stack_pop(s) == NULL, "An empty stack returns NULL if its tries to pop");
+    print_test(stack_top(s) == NULL, "An empty stack returns NULL if its tries to peek at the top");
+
     stack_destroy(s);
 }
 
@@ -24,18 +27,21 @@ static void test_stack_one_element(void) {
     printf("TEST: Tries the flow of pushing one element, peeking at the top and popping it out of the stack.\n");
 
     Stack s = stack_create();
-
+    void* top = NULL;
     int num = 44;
-    void* top;
 
     stack_push(s, &num);
     print_test(!stack_is_empty(s), "A stack with an element is not empty");
+
     top = stack_top(s);
     print_test(*(int*)top == num, "The element at the top of the stack has the same value as the one pushed before");
-    top = NULL;
+    print_test(!stack_is_empty(s), "Peeking at the top of the stack doesn't pop it");
+
     top = stack_pop(s);
     print_test(*(int*)top == num, "The element popped from the top has the same value as the one pushed before");
     print_test(stack_is_empty(s), "The stack is empty after its only element was popped from it.");
+
+    print_test(stack_pop(s) == NULL, "After popping its last element, there are no elements left in the stack");
 
     free(top);
     stack_destroy(s);
@@ -45,11 +51,10 @@ static void test_lifo(void) {
     printf("TEST: Verifies that the stack follows the LIFO principle correctly\n");
 
     Stack s = stack_create();
-
-    float elements[3] = {0.112358f, 3.14f, 2.71f};
-    char test_msg[60];
-    char* suffixes[3] = {"st", "nd", "rd"};
     void* top = NULL;
+    float elements[3] = {0.112358f, 3.14f, 2.71f};
+    char* suffixes[3] = {"st", "nd", "rd"};
+    char test_msg[60];
 
     for (int i = 0 ; i < 3 ; i++) {
         stack_push(s, &elements[i]);
@@ -58,12 +63,11 @@ static void test_lifo(void) {
 
     for (int i = 2; !stack_is_empty(s); i--) {
         sprintf(test_msg, "The %d%s element out is the %d%s pushed", 3-i, suffixes[2-i], i+1, suffixes[i]);
-        free(top);
         top = stack_pop(s);
         print_test(*(float*)top == elements[i], test_msg);
+        free(top);
     }
 
-    free(top);
     stack_destroy(s);
 }
 
@@ -77,7 +81,6 @@ static void test_bulk_lifo(void) {
         stack_push(s, &i);
         top = stack_top(s);
         print_test(*(int*)top == i, "The current top of the stack is the just pushed one");
-        print_test(!stack_is_empty(s), "The stack must not be empty when you keep pushing elements");
     }
 
     for (int i = BULK_AMOUNT - 1 ; i >= 0 ; i--) {
@@ -94,13 +97,13 @@ static void test_change_pushed_value(void) {
     printf("TEST: Verifies that if the value of a variable that was pushed into a stack is changed, the value inside the stack doesn't change\n");
 
     Stack s = stack_create();
-
-    char elem = 'a';
-    stack_push(s, &elem);
-    
     void* top = NULL;
+    char elem = 'a';
+
+    stack_push(s, &elem);
     top = stack_top(s);
     print_test(*(char*)top == elem, "The element at the top is the one pushed");
+    
     elem = 'b';
     top = stack_top(s);
     print_test(*(char*)top != elem, "After changing the value of the element that was pushed into the stack, the top of the stack didn't change");
@@ -108,12 +111,12 @@ static void test_change_pushed_value(void) {
     stack_destroy(s);
 }
 
-static void test_charge_stack(void) {
-    printf("TEST: Pushes some elements into the stack, pops all of them, and charges it back again to show it works like a newly created stack\n");
+static void test_emptied_stack(void) {
+    printf("TEST: Verifies that an emptied stack acts like a newly created stack\n");
 
     Stack s = stack_create();
-    bool ok = true;
     void* top = NULL;
+    bool ok = true;
 
     for(int i = 0 ; i < AMOUNT && ok ; i++) {
         stack_push(s, &i);
@@ -121,74 +124,17 @@ static void test_charge_stack(void) {
         ok = *(int*)top == i && !stack_is_empty(s);
     }
     print_test(ok, "A good amount of elements can be pushed into the stack");
-    
-    ok = true;
+
     for(int i = AMOUNT-1 ; i >= 0 && ok ; i--) {
-        void* top = stack_pop(s);
-        ok = *(int*)top == i;
-        free(top);
-    }
-    print_test(stack_is_empty(s), "After every element was popped from the stack, it should be empty");
-    print_test(ok, "The elements of the stack are popped in the opposite order to which they were pushed");
-
-    for(int i = 0 ; i < AMOUNT && ok ; i++) {
-        stack_push(s, &i);
-        top = stack_top(s);
-        ok = *(int*)top == i && !stack_is_empty(s);
-    }
-    print_test(ok, "After popping every element, the stack can still push a good amount of elements");
-
-    stack_destroy(s);
-}
-
-static void test_bulk_charge_stack(void) {
-    printf("TEST: Pushes a lot of elements into the stack, pops all of them, and charges it back again to check if the stack works correctly with lots of elements\n");
-
-    Stack s = stack_create();
-    bool ok = true;
-    void* top = NULL;
-
-    for(int i = 0 ; i < BULK_AMOUNT && ok ; i++) {
-        stack_push(s, &i);
-        top = stack_top(s);
-        ok = *(int*)top == i && !stack_is_empty(s);
-    }
-    print_test(ok, "A good amount of elements can be pushed into the stack");
-    
-    ok = true;
-    for(int i = BULK_AMOUNT-1 ; i >= 0 && ok ; i--) {
-        void* top = stack_pop(s);
-        ok = *(int*)top == i;
-        free(top);
-    }
-    print_test(stack_is_empty(s), "After every element was popped from the stack, it should be empty");
-    print_test(ok, "The elements of the stack are popped in the opposite order to which they were pushed");
-
-    for(int i = 0 ; i < BULK_AMOUNT && ok ; i++) {
-        stack_push(s, &i);
-        top = stack_top(s);
-        ok = *(int*)top == i && !stack_is_empty(s);
-    }
-    print_test(ok, "After popping every element, the stack can still push a good amount of elements");
-
-    stack_destroy(s);
-}
-
-void test_push_pop(void) {
-    printf("TEST: Pushes an element into the stack, pops it and repeats a good amount of times\n");
-
-    Stack s = stack_create();
-    void* top = NULL;
-    int num = 2;
-
-    stack_push(s, &num);
-    for (int i = 0 ; i < AMOUNT ; i++) {
         top = stack_pop(s);
-        int int_top = *(int*)top; 
-        print_test(int_top == num, "The element popped must be the one pushed");
-        stack_push(s, &int_top);
+        ok = *(int*)top == i;
         free(top);
     }
+
+    print_test(stack_is_empty(s), "A newly created stack must be empty");
+
+    print_test(stack_pop(s) == NULL, "An empty stack returns NULL if its tries to pop");
+    print_test(stack_top(s) == NULL, "An empty stack returns NULL if its tries to peek at the top");
 
     stack_destroy(s);
 }
@@ -199,9 +145,7 @@ int main(void) {
     test_lifo();
     test_bulk_lifo();
     test_change_pushed_value();
-    test_charge_stack();
-    test_bulk_charge_stack();
-    test_push_pop();
+    test_emptied_stack();
     
     return 0;
 }


### PR DESCRIPTION
**Change aborting the execution for returning NULL**
Now, the operations of the ADTs won't abort while the execution. Instead, they will return NULL if for example you try to pop from an empty stack Interfaces, implementation, tests and documentation changed accordingly.